### PR TITLE
fix(Screenshooting): replace - for _ of component names in urls

### DIFF
--- a/src/comparison/runBaseline.js
+++ b/src/comparison/runBaseline.js
@@ -5,7 +5,7 @@ describe('baseline_', () => {
     it(`${componentName}_${type}`, () => {
       process.env.SCREENSHOT_NAME = `${componentName}_${type}`
       browser
-        .url(`/iframe.html?full=1&selectedStory=${type}&selectedKind=${componentName}`)
+        .url(`/iframe.html?full=1&selectedStory=${type}&selectedKind=${componentName.replace(/-/g, "_")}`)
         .checkDocument()
         console.log(`Saved chrome baseline for ${componentName} (${type})`)
     })

--- a/src/comparison/runComparison.js
+++ b/src/comparison/runComparison.js
@@ -5,7 +5,7 @@ describe(`${browser.desiredCapabilities.browserName}_`, () => {
     it(`${componentName}_${type}`, () => {
       process.env.SCREENSHOT_NAME = `${componentName}_${type}`
       const report = browser
-        .url(`/iframe.html?full=1&selectedStory=${type}&selectedKind=${componentName}`)
+        .url(`/iframe.html?full=1&selectedStory=${type}&selectedKind=${componentName.replace(/-/g, "_")}`)
         .checkDocument()
 
       report.forEach(result => {


### PR DESCRIPTION
When screenshooting storybook couldn't find the page for _opinion-scale_. Turns out we weren't translating it to the url-friendly _opinion_scale_. This fixes it.