### PR TITLE
update wdio_browserstack to safer version

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "react": "^16.3.2",
     "react-dom": "^16.3.2",
     "rmdir": "^1.2.0",
-    "wdio-browserstack-service": "^0.1.16",
+    "wdio-browserstack-service": "^0.1.18",
     "wdio-mocha-framework": "^0.5.13",
     "wdio-selenium-standalone-service": "^0.0.10",
     "wdio-visual-regression-service": "^0.9.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2463,7 +2463,7 @@ browserslist@^4.1.0, browserslist@^4.3.3:
     electron-to-chromium "^1.3.82"
     node-releases "^1.0.1"
 
-browserstack-local@^1.2.0, browserstack-local@^1.3.7:
+browserstack-local@^1.3.7:
   version "1.3.7"
   resolved "https://registry.yarnpkg.com/browserstack-local/-/browserstack-local-1.3.7.tgz#cac9fc958eaa0a352e8f1ca1dc91bb141ba5da6f"
   integrity sha512-ilZlmiy7XYJxsztYan7XueHVr3Ix9EVh/mCiYN1G53wRPEW/hg1KMsseM6UExzVbexEqFEfwjkBLeFlSqxh+bQ==
@@ -12016,12 +12016,12 @@ wcwidth@^1.0.0:
   dependencies:
     defaults "^1.0.3"
 
-wdio-browserstack-service@^0.1.16:
-  version "0.1.16"
-  resolved "https://registry.yarnpkg.com/wdio-browserstack-service/-/wdio-browserstack-service-0.1.16.tgz#2a5d216d1af7d95e752095aba3c11eff68b92d64"
-  integrity sha1-Kl0hbRr32V51IJWro8Ee/2i5LWQ=
+wdio-browserstack-service@^0.1.18:
+  version "0.1.18"
+  resolved "https://registry.yarnpkg.com/wdio-browserstack-service/-/wdio-browserstack-service-0.1.18.tgz#1e29eae749ae4739ce8f8837c768a7493806c40b"
+  integrity sha512-6tISYMKzwr2oxx0yi2Q4GoFC2Mbq81iHhqxayacC4XgFR7QbmQkxwV8JPeq590AXhuhPqqmyuEGkMqc9fo/UoQ==
   dependencies:
-    browserstack-local "^1.2.0"
+    browserstack-local "^1.3.7"
     request "^2.81.0"
     request-promise "^4.2.1"
 


### PR DESCRIPTION
Although Snyk tells me browserstack was already rid of ps-tree vulnerability, let's force update wdio-browserstack just to be sure